### PR TITLE
Updated preset sections with variable substition example

### DIFF
--- a/docs/laravel.md
+++ b/docs/laravel.md
@@ -286,6 +286,45 @@ class BookController
         flash()->add{{ type | capitalize }}('{{ message }}', '{{ title }}');
 ```
 
+<p id="preset-variables"><a href="#preset-variables" class="anchor"><i class="fa-duotone fa-link"></i> Variables</a></p>
+
+Presets can also contain variables that can be substituted by using the translation system. Take the following example where you have a preset showing a personalised welcome message to the user.
+
+```php
+<?php // config/flasher.php
+
+return [
+    'presets' => [
+        'hello_user' => [
+            'type' => '{{ type }}',
+            'message' => 'welcome_back_user',
+        ],
+    ],
+];
+```
+
+In the translations file you can define `welcome_back_user` with the message containing the variable `:username`.
+
+```php
+<?php // /resources/lang/vendor/flasher/en/messages.php
+
+return [
+    'welcome_back_user' => 'Welcome back :username',
+];
+```
+
+If you want to substitute the `:username` in the above translation with a username in the controller, you can achieve this by passing an array of values to be substituted as the second argument.
+
+```php
+class BookController
+{
+    public function save()
+    {
+        $username = 'John Doe';
+
+        flash()->addPreset('hello_user', ['username' => $username]);
+```
+
 ---
 
 ## <i class="fa-duotone fa-list-radio"></i> Dark Mode 

--- a/docs/symfony.md
+++ b/docs/symfony.md
@@ -266,6 +266,40 @@ class BookController
         flash()->add{{ type | capitalize }}('{{ message }}', '{{ title }}');
 ```
 
+<p id="preset-variables"><a href="#preset-variables" class="anchor"><i class="fa-duotone fa-link"></i> Variables</a></p>
+
+Presets can also contain variables that can be substituted by using the translation system. Take the following example where you have a preset showing a personalised welcome message to the user.
+
+```yaml
+# config/packages/flasher.yaml
+
+flasher:
+    presets:
+        hello_user:
+            type: {{ type }}
+            message: welcome_back_user
+```
+
+In the translations file you can define `welcome_back_user` with the message containing the variable `:username`.
+
+```yaml
+# translations/flasher.en.yaml
+
+welcome_back_user: Welcome back :username
+```
+
+If you want to substitute the `:username` in the above translation with a username in the controller, you can achieve this by passing an array of values to be substituted as the second argument.
+
+```php
+class BookController
+{
+    public function save()
+    {
+        $username = 'John Doe';
+
+        flash()->addPreset('hello_user', ['username' => $username]);
+```
+
 ---
 
 ## <i class="fa-duotone fa-list-radio"></i> Dark Mode 


### PR DESCRIPTION
## What does this PR do?
Regarding https://github.com/php-flasher/php-flasher/issues/142, the [solution](https://github.com/php-flasher/php-flasher/issues/142#issuecomment-1565395627) that was provided can be documented to make it clear for other users that it is already possible to use variable substition for presets by using the translation files.

## Relevant Issues
- https://github.com/php-flasher/php-flasher/issues/142
